### PR TITLE
ニコニコ動画のプロトコル変更に対応するための変更

### DIFF
--- a/nicomenu.user.js
+++ b/nicomenu.user.js
@@ -24,12 +24,12 @@ let nicomenu = {
                  '<a href="http://www.nicovideo.jp/ranking/fav/total/all">合計</a>' +
              '</div>'
     },
-    
+
     insertRankingMenu() {
         let info = this._getPage();
         info && this[info.page](info.target);
     },
-    
+
     admin(nav) {
         let li = nav.querySelector(".siteHeaderOther").previousSibling.previousSibling;
         li.querySelector("A").appendChild(document.createTextNode("▼"));
@@ -53,7 +53,7 @@ let nicomenu = {
         });
         li.addEventListener("mouseout", mouseout);
     },
-    
+
     _getPage() {
         let nav = document.querySelector(".siteHeaderMenuList");
         if (nav) {

--- a/nicomenu.user.js
+++ b/nicomenu.user.js
@@ -2,7 +2,7 @@
 // @name        NicoMenUse
 // @namespace   http://www.atomer.sakura.ne.jp/
 // @description ニコニコ動画のヘッダーメニューの拡張
-// @include     *://www.nicovideo.jp/*
+// @include     https://www.nicovideo.jp/*
 // @version     0.2
 // ==/UserScript==
 const MENU_BUTTON_ID = "_nicomenu_menu_button";

--- a/nicomenu.user.js
+++ b/nicomenu.user.js
@@ -2,7 +2,7 @@
 // @name        NicoMenUse
 // @namespace   http://www.atomer.sakura.ne.jp/
 // @description ニコニコ動画のヘッダーメニューの拡張
-// @include     http://www.nicovideo.jp/*
+// @include     *://www.nicovideo.jp/*
 // @version     0.2
 // ==/UserScript==
 const MENU_BUTTON_ID = "_nicomenu_menu_button";


### PR DESCRIPTION
2018年10月11日 より、ニコニコ動画のプロトコルが http から https に変更されておりスクリプトが発火しなくなった。
参考: http://blog.nicovideo.jp/niconews/90007.html

これに対応するため、対象サイトの指定のうちプロトコルの部分をワイルドカードにする対応を入れる。

バージョンアップとリリースは、私にはできないので気が向いとときに対応お願いします。
愛用しています。便利なスクリプトありがとうございます。